### PR TITLE
Auto-publish to GitHub Pages via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 before_install:
   - cd notagame
 script:
+  - export PUBLIC_URL=$(echo $TRAVIS_REPO_SLUG | awk -F'/' '{OFS=""; print "https://",$1,".github.io/",$2}')
   - npm run build
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+node_js:
+  - "stable"
+cache:
+  directories:
+    - node_modules
+script:
+  - npm run build
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+  keep_history: true
+  local_dir: ./build
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,13 @@ cache:
   directories:
     - node_modules
 script:
+  - cd notagame
   - npm run build
 deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
   keep_history: true
-  local_dir: ./build
+  local_dir: ./notagame/build
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ node_js:
   - "stable"
 cache:
   directories:
-    - node_modules
-script:
+    - ./notagame/node_modules
+before_install:
   - cd notagame
+script:
   - npm run build
 deploy:
   provider: pages

--- a/notagame/public/index.html
+++ b/notagame/public/index.html
@@ -2,10 +2,11 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <base href="%PUBLIC_URL%/">
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" type="text/css" href="index.css">
-    <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville&display=swap" rel="stylesheet"> 
+    <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville&display=swap" rel="stylesheet">
     <title>Not a game</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -7,14 +7,9 @@
     "create-react-app": "^3.4.0",
     "tsv": "^0.2.0"
   },
-  "devDependencies": {
-    "gh-pages": "^2.2.0",
-    "react-scripts": "^3.4.0"
-  },
+  "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,13 @@
     "create-react-app": "^3.4.0",
     "tsv": "^0.2.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "gh-pages": "^2.2.0"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "tsv": "^0.2.0"
   },
   "devDependencies": {
-    "gh-pages": "^2.2.0"
+    "gh-pages": "^2.2.0",
+    "react-scripts": "^3.4.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
These changes should allow to `notagame` to automatically be published to GitHub Pages ( -> https://jugendhackt.github.io/notagame) on every push to master. The React App is built by Travis CI and then automatically pushed to the gh-pages branch.

See https://travis-ci.org/tiefpunkt/notagame and https://tiefpunkt.github.io/notagame/ for reference. 

Note that the `GITHUB_TOKEN` environment variable needs to be maintained in the Travis CI config for this repo to make the GH pages integration work.  It needs to be set to a personal access token (https://github.com/settings/tokens). I'm not quite sure how this works for organisations exactly, but I'm sure there's a good way to make that work.